### PR TITLE
Add thin disk provisioning & unit number to solve error

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -37,8 +37,9 @@ resource "vsphere_virtual_machine" "this" {
     content {
       label            = disk.value["label"]
       size             = disk.value["size"]
-      thin_provisioned = false
+      thin_provisioned = defaults(disk.value["thin_provisioned"], false)
       io_share_count   = 1000
+      unit_number      = index(var.disks, disk.value)
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -49,8 +49,9 @@ variable "memory" {
 variable "disks" {
   description = "A specification list for a virtual disk devices on this virtual machine."
   type = list(object({
-    label = string
-    size  = number
+    label            = string
+    size             = number
+    thin_provisioned = optional(bool)
   }))
 }
 


### PR DESCRIPTION
This PR adds thin disk provisioning as optional and disk unit number to solve [this issue](https://github.com/hashicorp/terraform-provider-vsphere/issues/569).